### PR TITLE
Remove conditional check in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,6 @@ jobs:
           distribution: 'zulu'
           java-version: 21
       - name: Setup gradle.properties
-        if: steps.check_version.outputs.version_exists == 'false'
         run: |
           # Create a minimal gradle.properties with only necessary properties for CI
           echo "android.useAndroidX=true" > gradle.properties


### PR DESCRIPTION
The conditional check has been removed when setting up `gradle.properties` in the publish workflow to simplify the configuration process. This change ensures smoother execution of the workflow.