### PR TITLE
Bump version to 1.0.5 in workflow and build files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  VERSION_NAME: 1.0.4  # Update this value for each release
+  VERSION_NAME: 1.0.5  # Update this value for each release
 
 jobs:
   release:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.2"
 composeBom = "2025.12.01"
-permissionsCompose = "1.0.4"
+permissionsCompose = "1.0.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/permissions-compose/build.gradle.kts
+++ b/permissions-compose/build.gradle.kts
@@ -59,14 +59,14 @@ mavenPublishing {
     publishToMavenCentral()
     signAllPublications()
 
-    coordinates("com.meticha", "permissions_compose", "1.0.4")
+    coordinates("com.meticha", "permissions_compose", "1.0.5")
 
     pom {
         name = "permissions_compose"
         description =
             "A lightweight Android library that simplifies runtime permission management in Jetpack Compose applications."
         inceptionYear = "2025"
-        version = "1.0.4"
+        version = "1.0.5"
         url = "https://github.com/meticha/permissions-compose.git"
         licenses {
             license {


### PR DESCRIPTION
Update project configuration files:

- Updated `VERSION_NAME` to `1.0.5` in `release.yaml`.
- Updated Maven coordinates and library version in `build.gradle.kts`.
- Bumped `permissionsCompose` version to `1.0.5` in `libs.versions.toml`.